### PR TITLE
Fixed typings for Safepay errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sfpy/node-core",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Official NodeJS Core to create SDKs for Safepay APIs",
   "main": "cjs/safepay.cjs.node.js",
   "types": "types/index.d.ts",

--- a/types/Errors.d.ts
+++ b/types/Errors.d.ts
@@ -13,18 +13,23 @@ declare module "@sfpy/node-core" {
                 readonly status?: number;
             };
             class SafepayInvalidRequestError extends SafepayError {
+                constructor(raw: SafepayRawError);
                 readonly type: 'SafepayInvalidRequestError';
             };
             class SafepayAPIError extends SafepayError {
+                constructor(raw: SafepayRawError);
                 readonly type: 'SafepayAPIError';
             };
             class SafepayAuthenticationError extends SafepayError {
+                constructor(raw: SafepayRawError);
                 readonly type: 'SafepayAuthenticationError';
             };
             class SafepayConflictError extends SafepayError {
+                constructor(raw: SafepayRawError);
                 readonly type: 'SafepayConflictError';
             };
             class SafepayUnknownError extends SafepayError {
+                constructor(raw: SafepayRawError);
                 readonly type: 'SafepayUnknownError';
             };
         }


### PR DESCRIPTION
# Description

Fixed typings for the errors so they can be thrown without passing the type in the constructor.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] UI change (Front-end UI update without breaking changes or business logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Description

1. **What is the current behavior?** (You can also link to an open issue here)

When importing the errors from the package (as in not using them internally to the package) one must specify the type of the error when creating a new error object. This is redundant as the type is already stipulated when the constructor calls super.

2. **What is the new behavior (if this is a feature change)?**

The types have been updated with the contructor argument types.

3. **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

# How Has This Been Tested?

Tested in Safepay Drops.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
